### PR TITLE
Fix tag parsing when image contains host and port

### DIFF
--- a/src/deployment-version-update.tsx
+++ b/src/deployment-version-update.tsx
@@ -88,7 +88,7 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
         {
           initContainers.length > 0 && (
             <>
-              <Renderer.Component.DrawerTitle title="InitContainer images" />
+              <Renderer.Component.DrawerTitle children="InitContainer images" />
               {
                 initContainers.map(([index, value]) => (
 
@@ -118,7 +118,7 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
         {
           containers.length > 0 && (
             <>
-              <Renderer.Component.DrawerTitle title="Container images" />
+              <Renderer.Component.DrawerTitle children="Container images" />
               {
                 containers.map(([index, value]) => (
 

--- a/src/deployment-version-update.tsx
+++ b/src/deployment-version-update.tsx
@@ -6,6 +6,9 @@ import { observable, makeObservable, autorun } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { Deployment } from './classes/deployment';
 
+// Based on https://regex101.com/r/nmSDPA/1
+const imageRegex = /^(?<name>(?:(?<domain>(?:localhost|[\w-]+(?:\.[\w-]+)+)(?::\d+)?|\w+:\d+)\/)?(?<image>[a-z0-9_.-]+(?:\/[a-z0-9_.-]+)*))(?::(?<tag>\w[\w.-]{0,127}))?(?:@(?<digest>[A-Za-z][A-Za-z0-9]*(?:[+.-_][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]{32,}))?$/;
+
 @observer
 export class DeploymentVersionUpdate extends React.Component<Renderer.Component.KubeObjectDetailsProps<Deployment>> {
 
@@ -24,12 +27,22 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
         const { object } = this.props;
 
         console.log(object);
+
+        const parse = (container: { name: string, image: string }) => {
+          const match = container.image.match(imageRegex);
+          return {
+            image: match.groups.name,
+            tag: (match.groups.tag ?? 'latest') + (match.groups.digest ? '@' + match.groups.digest : ''),
+            name: container.name
+          }
+        }
+
         if (object) {
           object.spec.template.spec.containers.forEach((container, index) => {
-            this.containers.set(index, { image: container.image.replace(/(?=:).*/, ""), tag: container.image.replace(/^.*?(?=:)/, "").substring(1), name: container.name });
+            this.containers.set(index, parse(container));
           });
           object.spec.template.spec.initContainers.forEach((container, index) => {
-            this.initContainers.set(index, { image: container.image.replace(/(?=:).*/, ""), tag: container.image.replace(/^.*?(?=:)/, "").substring(1), name: container.name });
+            this.initContainers.set(index, parse(container));
           });
         }
       }),
@@ -40,10 +53,10 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
     const { object } = this.props;
 
     for (const [index, value] of this.containers) {
-      object.spec.template.spec.containers[index].image = object.spec.template.spec.containers[index].image.replace(/:.*/, ':' + value.tag);
+      object.spec.template.spec.containers[index].image = value.image + ':' + value.tag;
     }
     for (const [index, value] of this.initContainers) {
-      object.spec.template.spec.initContainers[index].image = object.spec.template.spec.initContainers[index].image.replace(/:.*/, ':' + value.tag);
+      object.spec.template.spec.initContainers[index].image = value.image + ':' + value.tag;
     }
 
     try {

--- a/src/deployment-version-update.tsx
+++ b/src/deployment-version-update.tsx
@@ -4,19 +4,18 @@ import { Renderer } from "@k8slens/extensions";
 import React from "react";
 import { observable, makeObservable, autorun } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
-import { Deployment } from './classes/deployment';
 
 // Based on https://regex101.com/r/nmSDPA/1
 const imageRegex = /^(?<name>(?:(?<domain>(?:localhost|[\w-]+(?:\.[\w-]+)+)(?::\d+)?|\w+:\d+)\/)?(?<image>[a-z0-9_.-]+(?:\/[a-z0-9_.-]+)*))(?::(?<tag>\w[\w.-]{0,127}))?(?:@(?<digest>[A-Za-z][A-Za-z0-9]*(?:[+.-_][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]{32,}))?$/;
 
 @observer
-export class DeploymentVersionUpdate extends React.Component<Renderer.Component.KubeObjectDetailsProps<Deployment>> {
+export class DeploymentVersionUpdate extends React.Component<Renderer.Component.KubeObjectDetailsProps<Renderer.K8sApi.Deployment>> {
 
   @observable isSaving = false;
   @observable containers = observable.map<number, { image: string, tag: string, name: string }>();
   @observable initContainers = observable.map<number, { image: string, tag: string, name: string }>();
 
-  constructor(props: Renderer.Component.KubeObjectDetailsProps<Deployment>) {
+  constructor(props: Renderer.Component.KubeObjectDetailsProps<Renderer.K8sApi.Deployment>) {
     super(props);
     makeObservable(this);
   }
@@ -28,7 +27,7 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
 
         console.log(object);
 
-        const parse = (container: { name: string, image: string }) => {
+        const parse = (container: Renderer.K8sApi.IPodContainer) => {
           const match = container.image.match(imageRegex);
           return {
             image: match.groups.name,

--- a/src/deployment-version-update.tsx
+++ b/src/deployment-version-update.tsx
@@ -88,7 +88,7 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
         {
           initContainers.length > 0 && (
             <>
-              <Renderer.Component.DrawerTitle children="InitContainer images" />
+              <Renderer.Component.DrawerTitle children={`InitContainer image${initContainers.length > 1 ? 's' : ''}`} />
               {
                 initContainers.map(([index, value]) => (
 
@@ -118,7 +118,7 @@ export class DeploymentVersionUpdate extends React.Component<Renderer.Component.
         {
           containers.length > 0 && (
             <>
-              <Renderer.Component.DrawerTitle children="Container images" />
+              <Renderer.Component.DrawerTitle children={`Container image${containers.length > 1 ? 's' : ''}`} />
               {
                 containers.map(([index, value]) => (
 


### PR DESCRIPTION
Hello there. I really liked the idea of this extension, but when I tried to use it in my working environment, I ran into a problem with the wrong parsing of the docker image name and tag. This is due to an unaccounted case where the docker image name contains the hostname followed by the port. I used a regular expression from https://regex101.com/r/nmSDPA/1, you can check the link to see all the possible inputs that are parsed correctly.

I also fixed the missing title of the side menu UI component that was not displayed due to the use of deprecated property, and changed the title to use singular or plural form (image/images) depending on the number of containers.